### PR TITLE
Track changes in mathics-core

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,6 @@ root = true
 
 [*]
 end_of_line = lf
-insert_final_newline = true
 charset = utf-8
 indent_style = tab
 indent_size = 4

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 |Pypi Installs| |Latest Version| |Supported Python Versions|
 
-`Mathics <https://mathics.org>`_ Graph Module using `NetworkX <https://networkx.org/>`_ and `Matplotlib <https://matplotlib.org>`_
+`Mathics3 <https://mathics.org>`_ Graph Module using `NetworkX <https://networkx.org/>`_ and `Matplotlib <https://matplotlib.org>`_
 
 Example Session
 ---------------

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ import os.path as osp
 from setuptools import setup, find_namespace_packages
 
 # Ensure user has the correct Python version
-if sys.version_info < (3, 7):
-    print("Mathics support Python 3.7 and above; you have %d.%d" % sys.version_info[:2])
+if sys.version_info < (3, 8):
+    print("Mathics support Python 3.8 and above; you have %d.%d" % sys.version_info[:2])
     sys.exit(-1)
 
 
@@ -28,11 +28,11 @@ long_description = read("README.rst") + "\n"
 is_PyPy = platform.python_implementation() == "PyPy"
 
 setup(
-    name="pymathics-graph",
+    name="Mathics3-graph",
     version=__version__,  # noqa
     packages=find_namespace_packages(include=["pymathics.*"]),
     install_requires=[
-        "Mathics3>=7.0.0dev",
+        "Mathics3>=7.0.0.dev0",
         "networkx>=3.0.0",
         "pydot",
         "matplotlib",
@@ -50,10 +50,10 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Scientific/Engineering",

--- a/test/consistency-and-style/test_summary_text.py
+++ b/test/consistency-and-style/test_summary_text.py
@@ -10,8 +10,7 @@ from pymathics.graph import __file__ as module_initfile_path
 
 from mathics.core.builtin import Builtin
 from mathics.core.load_builtin import name_is_builtin_symbol
-from mathics.doc.common_doc import skip_doc
-
+from mathics.doc.gather import skip_doc
 
 # Get file system path name for mathics.builtin
 module_path = osp.dirname(module_initfile_path)


### PR DESCRIPTION
`setup.py`: We need at least Python 3.8
`.editorconfig`: remove duplicate config line
<strike> `__init__.py`:  add just in case</strike> Adding would mess up other Mathics3 modules.
`test_summary_text.py`: import location has moved