### PR TITLE
sort_connected_components

### DIFF
--- a/pymathics/graph/components.py
+++ b/pymathics/graph/components.py
@@ -60,7 +60,7 @@ generated/networkx.algorithms.components.strongly_connected_components.html</url
                 if graph.G.is_directed()
                 else nx.connected_components
             )
-            components = [to_mathics_list(*c) for c in connect_fn(graph.G)]
+            components = [to_mathics_list(*sorted(c)) for c in connect_fn(graph.G)]
             return ListExpression(*components)
 
 


### PR DESCRIPTION
In WMA, `ConnectedComponents` returns a list of sorted elements. The result of networkx was compabible with this behaviour until  `3.1`, where the result seems to be returned unsorted. This makes doctests fail in master for Python 3.10.  This PR should fix that issue.