### PR TITLE
Roll in 3.14 roll out 3.10

### DIFF
--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -23,8 +23,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest setuptools
         python -m pip install Mathics3-Module-Base
+        # Until the next Mathics3-scanner release
+        python -m pip install -e git+https://github.com/Mathics3/Mathics3-scanner#egg=Mathics3_Scanner[full]
         # Until the next mathics-core release
-        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         git clone https://github.com/Mathics3/mathics-core
         (cd mathics-core && python -m pip install --no-build-isolation -e .[full])
         (cd mathics-core && bash ./admin-tools/make-JSON-tables.sh)

--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -24,7 +24,8 @@ jobs:
         python -m pip install pytest setuptools
         python -m pip install Mathics3-Module-Base
         # Until the next Mathics3-scanner release
-        python -m pip install -e git+https://github.com/Mathics3/Mathics3-scanner#egg=Mathics3_Scanner[full]
+        git clone https://github.com/Mathics3/Mathics3-scanner
+        (cd Mathics3-scanner && pip3 install -e .[full] --no-build-isolation && bash -x ./admin-tools/make-JSON-tables.sh)
         # Until the next mathics-core release
         git clone https://github.com/Mathics3/mathics-core
         (cd mathics-core && python -m pip install --no-build-isolation -e .[full])

--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -13,20 +13,20 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install pytest setuptools
         python -m pip install Mathics3-Module-Base
         # Until the next mathics-core release
         # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         git clone https://github.com/Mathics3/mathics-core
-        (cd mathics-core && python -m pip install -e .[full])
+        (cd mathics-core && python -m pip install --no-build-isolation -e .[full])
         (cd mathics-core && bash ./admin-tools/make-JSON-tables.sh)
 
     - name: Install Mathics3-Module-Networkx.graph with minimum dependencies

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,11 +24,13 @@ jobs:
         python -m pip install pytest
         python -m pip install Mathics3-Module-Base
         # Go over and comment out stuff when next Mathics core and Mathics-scanner are released
+        git clone https://github.com/Mathics3/Mathics3-scanner
+        (cd Mathics3-scanner && pip3 install -e .[full] --no-build-isolation && bash -x ./admin-tools/make-JSON-tables.sh)
         # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         # Until the next mathics-core release
         git clone https://github.com/Mathics3/mathics-core
-        (cd mathics-core && pip3 install -e .[full])
-        (cd mathics-core && bash ./admin-tools/make-JSON-tables.sh)
+        (cd mathics-core && pip3 install -e .[full] --no-build-isolation)
+        (cd mathics-core && bash -x ./admin-tools/make-JSON-tables.sh)
 
     - name: install Mathics3 Module networkx
       run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest setuptools
         python -m pip install Mathics3-Module-Base
-        # Go over and comment out stuff when next Mathics core and Mathics-scanner are released
+        # Go over and comment out stuff when next Mathics core and Mathics3-scanner are released
         git clone https://github.com/Mathics3/Mathics3-scanner
         (cd Mathics3-scanner && pip3 install -e .[full] --no-build-isolation && bash -x ./admin-tools/make-JSON-tables.sh)
         # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.14', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install pytest setuptools
         python -m pip install Mathics3-Module-Base
         # Go over and comment out stuff when next Mathics core and Mathics-scanner are released
         git clone https://github.com/Mathics3/Mathics3-scanner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,18 +20,17 @@ dependencies = [
         "matplotlib",
         "scipy>=1.10.0",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.rst"
 license = "GPL-3.0-or-later"
 keywords = ["Mathematica", "Wolfram", "Interpreter", "Shell", "Math", "CAS"]
 maintainers = [
-    {name = "Mathics Group", email = "mathics-devel@googlegroups.com"},
+    {name = "Mathics3 Group", email = "mathics-devel@googlegroups.com"},
 ]
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 name = "Mathics3-Module-networkx"
 description = "Mathics3 Graph Module using NetworkX"
 dependencies = [
-        "Mathics3>=9.0.0",
+        "Mathics3>9.0.0",
         "Mathics3-Module-Base",
         "mpmath>=1.2.0",
         "networkx>=3.0.0",


### PR DESCRIPTION
Roll in Python 3.14 testing. Drop support for Python 3.10. (It may still work, but it is unsupported.)

Track changes in scanner names and tables.